### PR TITLE
made sure that debugging `seq!` is possible

### DIFF
--- a/ifc_rs/src/geometry/arbitrary_closed_profile_def/deserialize.rs
+++ b/ifc_rs/src/geometry/arbitrary_closed_profile_def/deserialize.rs
@@ -8,7 +8,7 @@ use crate::parser::*;
 impl IFCParse for ArbitraryClosedProfileDef {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            ArbitraryClosedProfileDef {
                 _: p_space_or_comment_surrounded("IFCARBITRARYCLOSEDPROFILEDEF("),
 
                 profile_type: ProfileType::parse(),

--- a/ifc_rs/src/geometry/extruded_area_solid.rs
+++ b/ifc_rs/src/geometry/extruded_area_solid.rs
@@ -104,7 +104,7 @@ impl<'a> IfcMappedType<'a> for ExtrudedAreaSolid {
 impl IFCParse for ExtrudedAreaSolid {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            ExtrudedAreaSolid {
                 _: p_space_or_comment_surrounded("IFCEXTRUDEDAREASOLID("),
 
                 swept_area: Id::parse(),

--- a/ifc_rs/src/geometry/local_placement/mod.rs
+++ b/ifc_rs/src/geometry/local_placement/mod.rs
@@ -54,7 +54,7 @@ impl LocalPlacement {
 impl IFCParse for LocalPlacement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            LocalPlacement {
                 _: p_space_or_comment_surrounded("IFCLOCALPLACEMENT("),
 
                 placement_rel_to: OptionalParameter::parse(),

--- a/ifc_rs/src/geometry/non_uniform_transformations.rs
+++ b/ifc_rs/src/geometry/non_uniform_transformations.rs
@@ -110,7 +110,7 @@ impl IFCParse for CartesianTransformationOperator3DnonUniform {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            CartesianTransformationOperator3DnonUniform {
                 _: p_space_or_comment_surrounded("IFCCARTESIANTRANSFORMATIONOPERATOR3DNONUNIFORM("),
                 base: Transform3DBase::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/geometry/polyline/deserialize.rs
+++ b/ifc_rs/src/geometry/polyline/deserialize.rs
@@ -4,7 +4,7 @@ use crate::parser::{list::IfcList, *};
 impl IFCParse for PolyLine {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            PolyLine {
                 _: p_space_or_comment_surrounded("IFCPOLYLINE("),
                 points: IfcList::parse(),
                 _: p_space_or_comment_surrounded(");"),

--- a/ifc_rs/src/geometry/product_definition_shape/deserialize.rs
+++ b/ifc_rs/src/geometry/product_definition_shape/deserialize.rs
@@ -11,7 +11,7 @@ impl IFCParse for ProductDefinitionShape {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            ProductDefinitionShape {
                 _: p_space_or_comment_surrounded("IFCPRODUCTDEFINITIONSHAPE("),
                 name: OptionalParameter::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/geometry/rectangle_profile_def/deserialize.rs
+++ b/ifc_rs/src/geometry/rectangle_profile_def/deserialize.rs
@@ -9,7 +9,7 @@ use super::RectangleProfileDef;
 impl IFCParse for RectangleProfileDef {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RectangleProfileDef {
                 _: p_space_or_comment_surrounded("IFCRECTANGLEPROFILEDEF("),
 
                 profile_type: ProfileType::parse(),

--- a/ifc_rs/src/geometry/representation_context/deserialize.rs
+++ b/ifc_rs/src/geometry/representation_context/deserialize.rs
@@ -8,7 +8,7 @@ use crate::{
 impl IFCParse for GeometricRepresentationContext {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            GeometricRepresentationContext {
                 _: "IFCGEOMETRICREPRESENTATIONCONTEXT(",
                 context_identifier: OptionalParameter::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/geometry/representation_subcontext/deserialize.rs
+++ b/ifc_rs/src/geometry/representation_subcontext/deserialize.rs
@@ -12,7 +12,7 @@ use crate::{
 impl IFCParse for GeometricRepresentationSubContext {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            GeometricRepresentationSubContext {
                 _: "IFCGEOMETRICREPRESENTATIONSUBCONTEXT(",
                 context_identifier: OptionalParameter::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/geometry/shape_representation/deserialize.rs
+++ b/ifc_rs/src/geometry/shape_representation/deserialize.rs
@@ -14,7 +14,7 @@ impl IFCParse for ShapeRepresentation {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            ShapeRepresentation {
                 _: p_space_or_comment_surrounded("IFCSHAPEREPRESENTATION("),
                 context_of_items: Id::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/geometry/transform_base.rs
+++ b/ifc_rs/src/geometry/transform_base.rs
@@ -91,7 +91,7 @@ impl IFCParse for Transform3DBase {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            Transform3DBase {
                 axis_x: OptionalParameter::parse(),
                 _: Comma::parse(),
                 axis_y: OptionalParameter::parse(),

--- a/ifc_rs/src/geometry/uniform_transformations.rs
+++ b/ifc_rs/src/geometry/uniform_transformations.rs
@@ -82,7 +82,7 @@ impl IFCParse for CartesianTransformationOperator3D {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            CartesianTransformationOperator3D {
                 _: p_space_or_comment_surrounded("IFCCARTESIANTRANSFORMATIONOPERATOR3D("),
                 base: Transform3DBase::parse(),
                 _: p_space_or_comment_surrounded(");"),

--- a/ifc_rs/src/lib.rs
+++ b/ifc_rs/src/lib.rs
@@ -4,6 +4,7 @@
 use anyhow::{anyhow, Context, Result};
 use parser::IFCParse;
 use std::{fmt::Display, fs, path::Path, str::FromStr};
+use winnow::Parser;
 
 use meta::{
     datamap::DataMap,
@@ -79,7 +80,6 @@ impl IFC {
     }
 }
 
-
 impl IFCParse for IFC {
     fn parse<'a>() -> impl parser::IFCParser<'a, Self> {
         winnow::seq! {
@@ -96,7 +96,8 @@ impl FromStr for IFC {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let me = s.parse::<IFC>()
+        let me = IFC::parse()
+            .parse(s)
             .map_err(|err| anyhow!("parsing failed: {err:#?}"))?;
 
         for (id, ifc_type) in me.data.0.iter() {

--- a/ifc_rs/src/lib.rs
+++ b/ifc_rs/src/lib.rs
@@ -4,7 +4,6 @@
 use anyhow::{anyhow, Context, Result};
 use parser::IFCParse;
 use std::{fmt::Display, fs, path::Path, str::FromStr};
-use winnow::{seq, Parser};
 
 use meta::{
     datamap::DataMap,
@@ -80,17 +79,25 @@ impl IFC {
     }
 }
 
+
+impl IFCParse for IFC {
+    fn parse<'a>() -> impl parser::IFCParser<'a, Self> {
+        winnow::seq! {
+            IFC {
+                header: Header::parse(),
+                data: DataMap::parse(),
+                footer: Footer::parse(),
+            }
+        }
+    }
+}
+
 impl FromStr for IFC {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let me = seq!(Self {
-            header: Header::parse(),
-            data: DataMap::parse(),
-            footer: Footer::parse(),
-        })
-        .parse(s)
-        .map_err(|err| anyhow!("parsing failed: {err:#?}"))?;
+        let me = s.parse::<IFC>()
+            .map_err(|err| anyhow!("parsing failed: {err:#?}"))?;
 
         for (id, ifc_type) in me.data.0.iter() {
             ifc_type.verify_id_types(&me).context(format!("ID: {id}"))?;

--- a/ifc_rs/src/materials/material.rs
+++ b/ifc_rs/src/materials/material.rs
@@ -51,7 +51,7 @@ impl Material {
 impl IFCParse for Material {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Material {
                 _: p_space_or_comment_surrounded("IFCMATERIAL("),
 
                 material: OptionalParameter::parse(),

--- a/ifc_rs/src/materials/material_constituent.rs
+++ b/ifc_rs/src/materials/material_constituent.rs
@@ -82,7 +82,7 @@ impl MaterialConstituent {
 impl IFCParse for MaterialConstituent {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MaterialConstituent {
                 _: p_space_or_comment_surrounded("IFCMATERIALCONSTITUENT("),
 
                 name: OptionalParameter::parse(),

--- a/ifc_rs/src/materials/material_constituent_set.rs
+++ b/ifc_rs/src/materials/material_constituent_set.rs
@@ -70,7 +70,7 @@ impl MaterialConstituentSet {
 impl IFCParse for MaterialConstituentSet {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MaterialConstituentSet {
                 _: p_space_or_comment_surrounded("IFCMATERIALCONSTITUENTSET("),
 
                 name: OptionalParameter::parse(),

--- a/ifc_rs/src/materials/material_layer.rs
+++ b/ifc_rs/src/materials/material_layer.rs
@@ -111,7 +111,7 @@ impl MaterialLayer {
 impl IFCParse for MaterialLayer {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MaterialLayer {
                 _: p_space_or_comment_surrounded("IFCMATERIALLAYER("),
 
                 material: OptionalParameter::parse(),

--- a/ifc_rs/src/materials/material_layer_set.rs
+++ b/ifc_rs/src/materials/material_layer_set.rs
@@ -63,7 +63,7 @@ impl MaterialLayerSet {
 impl IFCParse for MaterialLayerSet {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MaterialLayerSet {
                 _: p_space_or_comment_surrounded("IFCMATERIALLAYERSET("),
 
                 material_layers: IfcList::parse(),

--- a/ifc_rs/src/materials/material_layer_set_usage.rs
+++ b/ifc_rs/src/materials/material_layer_set_usage.rs
@@ -88,7 +88,7 @@ impl MaterialLayerSetUsage {
 impl IFCParse for MaterialLayerSetUsage {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MaterialLayerSetUsage {
                 _: p_space_or_comment_surrounded("IFCMATERIALLAYERSETUSAGE("),
 
                 spatial_element_structure: Id::parse().map(TypedId::new),

--- a/ifc_rs/src/meta/footer/deserialize.rs
+++ b/ifc_rs/src/meta/footer/deserialize.rs
@@ -11,7 +11,7 @@ use crate::parser::*;
 impl IFCParse for Footer {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Footer {
                 _: p_space_or_comment(),
                 version: p_footer_version(),
                 _: p_space_or_comment(),

--- a/ifc_rs/src/meta/header/deserialize.rs
+++ b/ifc_rs/src/meta/header/deserialize.rs
@@ -21,7 +21,7 @@ use crate::parser::*;
 impl IFCParse for Header {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Header {
                 _: p_space_or_comment(),
                 version: Self::p_version(),
                 _: p_space_or_comment_surrounded("HEADER;"),

--- a/ifc_rs/src/objects/application/deserialize.rs
+++ b/ifc_rs/src/objects/application/deserialize.rs
@@ -7,7 +7,7 @@ use crate::{
 impl IFCParse for Application {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Application {
                 _ : "IFCAPPLICATION(",
                 application_developer: TypedId::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/objects/building.rs
+++ b/ifc_rs/src/objects/building.rs
@@ -117,7 +117,7 @@ impl DerefMut for Building {
 impl IFCParse for Building {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Building {
                 _: p_space_or_comment_surrounded("IFCBUILDING("),
 
                 spatial_element_structure: SpatialStructureElement::parse(),

--- a/ifc_rs/src/objects/door/deserialize.rs
+++ b/ifc_rs/src/objects/door/deserialize.rs
@@ -9,7 +9,7 @@ use super::Door;
 impl IFCParse for Door {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Door {
                 _: alt((p_space_or_comment_surrounded("IFCDOOR("), p_space_or_comment_surrounded("IFCDOORSTANDARDCASE("))),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/doortype/deserialize.rs
+++ b/ifc_rs/src/objects/doortype/deserialize.rs
@@ -16,7 +16,7 @@ use super::DoorType;
 impl IFCParse for DoorType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            DoorType {
                 _: p_space_or_comment_surrounded("IFCDOORTYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/objects/opening_element/deserialize.rs
+++ b/ifc_rs/src/objects/opening_element/deserialize.rs
@@ -8,7 +8,7 @@ use super::OpeningElement;
 impl IFCParse for OpeningElement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            OpeningElement {
                 _: p_space_or_comment_surrounded("IFCOPENINGELEMENT("),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/project.rs
+++ b/ifc_rs/src/objects/project.rs
@@ -62,7 +62,7 @@ impl DerefMut for Project {
 impl IFCParse for Project {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Project {
                 _: p_space_or_comment_surrounded("IFCPROJECT("),
 
                 context: Context::parse(),

--- a/ifc_rs/src/objects/roof/deserialize.rs
+++ b/ifc_rs/src/objects/roof/deserialize.rs
@@ -8,7 +8,7 @@ use super::Roof;
 impl IFCParse for Roof {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Roof {
                 _: p_space_or_comment_surrounded("IFCROOF("),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/rooftype/deserialize.rs
+++ b/ifc_rs/src/objects/rooftype/deserialize.rs
@@ -8,7 +8,7 @@ use super::RoofType;
 impl IFCParse for RoofType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RoofType {
                 _: p_space_or_comment_surrounded("IFCROOFTYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/objects/shading_device.rs
+++ b/ifc_rs/src/objects/shading_device.rs
@@ -48,7 +48,7 @@ impl ShadingDevice {
 impl IFCParse for ShadingDevice {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            ShadingDevice {
                 _: p_space_or_comment_surrounded("IFCSHADINGDEVICE("),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/shading_device_type.rs
+++ b/ifc_rs/src/objects/shading_device_type.rs
@@ -46,7 +46,7 @@ impl ShadingDeviceType {
 impl IFCParse for ShadingDeviceType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            ShadingDeviceType {
                 _: p_space_or_comment_surrounded("IFCSHADINGDEVICETYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/objects/shared/context.rs
+++ b/ifc_rs/src/objects/shared/context.rs
@@ -120,7 +120,7 @@ impl DerefMut for Context {
 impl IFCParse for Context {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Context {
                 root: Root::parse(),
                 _: Comma::parse(),
                 object_type: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/element.rs
+++ b/ifc_rs/src/objects/shared/element.rs
@@ -63,7 +63,7 @@ impl DerefMut for Element {
 impl IFCParse for Element {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Element {
                 product: Product::parse(),
                 _: Comma::parse(),
                 tag: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/element_type.rs
+++ b/ifc_rs/src/objects/shared/element_type.rs
@@ -67,7 +67,7 @@ impl DerefMut for ElementType {
 impl IFCParse for ElementType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            ElementType {
                 type_product: TypeProduct::parse(),
                 _: Comma::parse(),
                 element_type: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/object.rs
+++ b/ifc_rs/src/objects/shared/object.rs
@@ -63,7 +63,7 @@ impl DerefMut for Object {
 impl IFCParse for Object {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Object {
                 root: Root::parse(),
                 _: Comma::parse(),
                 object_type: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/product.rs
+++ b/ifc_rs/src/objects/shared/product.rs
@@ -156,7 +156,7 @@ impl DerefMut for Product {
 impl IFCParse for Product {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Product {
                 object: Object::parse(),
                 _: Comma::parse(),
                 object_placement: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/rel_associates.rs
+++ b/ifc_rs/src/objects/shared/rel_associates.rs
@@ -70,7 +70,7 @@ impl DerefMut for RelAssociates {
 impl IFCParse for RelAssociates {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelAssociates {
                 root: Root::parse(),
                 _: Comma::parse(),
                 related_objects: IfcList::parse(),

--- a/ifc_rs/src/objects/shared/root.rs
+++ b/ifc_rs/src/objects/shared/root.rs
@@ -75,7 +75,7 @@ pub trait RootBuilder: Sized {
 impl IFCParse for Root {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Root {
                 global_id: IfcGloballyUniqueId::parse(),
                 _: Comma::parse(),
                 owner_history: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/spatial_element.rs
+++ b/ifc_rs/src/objects/shared/spatial_element.rs
@@ -64,7 +64,7 @@ impl DerefMut for SpatialElement {
 impl IFCParse for SpatialElement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            SpatialElement {
                 product: Product::parse(),
                 _: Comma::parse(),
                 long_name: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/spatial_structure_element.rs
+++ b/ifc_rs/src/objects/shared/spatial_structure_element.rs
@@ -64,7 +64,7 @@ impl DerefMut for SpatialStructureElement {
 impl IFCParse for SpatialStructureElement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            SpatialStructureElement {
                 spatial_element: SpatialElement::parse(),
                 _: Comma::parse(),
                 composition_type: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/type_object.rs
+++ b/ifc_rs/src/objects/shared/type_object.rs
@@ -79,7 +79,7 @@ impl DerefMut for TypeObject {
 impl IFCParse for TypeObject {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            TypeObject {
                 root: Root::parse(),
                 _: Comma::parse(),
                 applicable_occurence: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/shared/type_product.rs
+++ b/ifc_rs/src/objects/shared/type_product.rs
@@ -83,7 +83,7 @@ impl DerefMut for TypeProduct {
 impl IFCParse for TypeProduct {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            TypeProduct {
                 type_object: TypeObject::parse(),
                 _: Comma::parse(),
                 representation_maps: OptionalParameter::parse(),

--- a/ifc_rs/src/objects/site.rs
+++ b/ifc_rs/src/objects/site.rs
@@ -169,7 +169,7 @@ impl DerefMut for Site {
 impl IFCParse for Site {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Site {
                 _: p_space_or_comment_surrounded("IFCSITE("),
 
                 spatial_element_structure: SpatialStructureElement::parse(),

--- a/ifc_rs/src/objects/slab/deserialize.rs
+++ b/ifc_rs/src/objects/slab/deserialize.rs
@@ -9,7 +9,7 @@ use super::Slab;
 impl IFCParse for Slab {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Slab {
                 _: alt((p_space_or_comment_surrounded("IFCSLAB("), p_space_or_comment_surrounded("IFCSLABSTANDARDCASE("))),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/slabtype/deserialize.rs
+++ b/ifc_rs/src/objects/slabtype/deserialize.rs
@@ -8,7 +8,7 @@ use super::SlabType;
 impl IFCParse for SlabType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            SlabType {
                 _: p_space_or_comment_surrounded("IFCSLABTYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/objects/space/deserialize.rs
+++ b/ifc_rs/src/objects/space/deserialize.rs
@@ -9,7 +9,7 @@ use super::Space;
 impl IFCParse for Space {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Space {
                 _: p_space_or_comment_surrounded("IFCSPACE("),
 
                 spatial_element_structure: SpatialStructureElement::parse(),

--- a/ifc_rs/src/objects/spacetype/deserialize.rs
+++ b/ifc_rs/src/objects/spacetype/deserialize.rs
@@ -13,7 +13,7 @@ use super::SpaceType;
 impl IFCParse for SpaceType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            SpaceType {
                 _: p_space_or_comment_surrounded("IFCSPACETYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/objects/storey.rs
+++ b/ifc_rs/src/objects/storey.rs
@@ -126,7 +126,7 @@ impl DerefMut for Storey {
 impl IFCParse for Storey {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Storey {
                 _: p_space_or_comment_surrounded("IFCBUILDINGSTOREY("),
 
                 spatial_element_structure: SpatialStructureElement::parse(),

--- a/ifc_rs/src/objects/wall/deserialize.rs
+++ b/ifc_rs/src/objects/wall/deserialize.rs
@@ -9,7 +9,7 @@ use super::Wall;
 impl IFCParse for Wall {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Wall {
                 _: alt((p_space_or_comment_surrounded("IFCWALL("), p_space_or_comment_surrounded("IFCWALLSTANDARDCASE("))),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/walltype/deserialize.rs
+++ b/ifc_rs/src/objects/walltype/deserialize.rs
@@ -10,7 +10,7 @@ use super::WallType;
 impl IFCParse for WallType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            WallType {
                 _: p_space_or_comment_surrounded("IFCWALLTYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/objects/window/deserialize.rs
+++ b/ifc_rs/src/objects/window/deserialize.rs
@@ -9,7 +9,7 @@ use super::Window;
 impl IFCParse for Window {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            Window {
                 _: alt((p_space_or_comment_surrounded("IFCWINDOW("), p_space_or_comment_surrounded("IFCWINDOWSTANDARDCASE("))),
 
                 element: Element::parse(),

--- a/ifc_rs/src/objects/windowtype/deserialize.rs
+++ b/ifc_rs/src/objects/windowtype/deserialize.rs
@@ -17,7 +17,7 @@ use super::WindowType;
 impl IFCParse for WindowType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            WindowType {
                 _: p_space_or_comment_surrounded("IFCWINDOWTYPE("),
 
                 element_type: ElementType::parse(),

--- a/ifc_rs/src/properties/base.rs
+++ b/ifc_rs/src/properties/base.rs
@@ -46,7 +46,7 @@ impl IFCParse for PropertyBase {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            PropertyBase {
                 name: OptionalParameter::parse(),
                 _: Comma::parse(),
                 description: OptionalParameter::parse(),

--- a/ifc_rs/src/properties/extended_base.rs
+++ b/ifc_rs/src/properties/extended_base.rs
@@ -58,7 +58,7 @@ impl IFCParse for ExtendedPropertyBase {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            ExtendedPropertyBase {
                 name: OptionalParameter::parse(),
                 _: Comma::parse(),
                 description: OptionalParameter::parse(),

--- a/ifc_rs/src/properties/material.rs
+++ b/ifc_rs/src/properties/material.rs
@@ -52,7 +52,7 @@ impl Deref for MaterialProperties {
 impl IFCParse for MaterialProperties {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MaterialProperties {
                 _: p_space_or_comment_surrounded("IFCMATERIALPROPERTIES("),
 
                 base: ExtendedPropertyBase::parse(),

--- a/ifc_rs/src/properties/set.rs
+++ b/ifc_rs/src/properties/set.rs
@@ -69,7 +69,7 @@ impl Deref for PropertySet {
 impl IFCParse for PropertySet {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            PropertySet {
                 _: p_space_or_comment_surrounded("IFCPROPERTYSET("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/properties/single_value.rs
+++ b/ifc_rs/src/properties/single_value.rs
@@ -56,7 +56,7 @@ impl IFCParse for PropertySingleValue {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            PropertySingleValue {
                 _: p_space_or_comment_surrounded("IFCPROPERTYSINGLEVALUE("),
 
                 base: PropertyBase::parse(),

--- a/ifc_rs/src/relations/mapped_item.rs
+++ b/ifc_rs/src/relations/mapped_item.rs
@@ -124,7 +124,7 @@ impl IFCParse for MappedItem {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            MappedItem {
                 _: p_space_or_comment_surrounded("IFCMAPPEDITEM("),
                 source: IdOr::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/relations/rel_aggregates.rs
+++ b/ifc_rs/src/relations/rel_aggregates.rs
@@ -66,7 +66,7 @@ impl Deref for RelAggregates {
 impl IFCParse for RelAggregates {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelAggregates {
                 _: p_space_or_comment_surrounded("IFCRELAGGREGATES("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/rel_associates_material.rs
+++ b/ifc_rs/src/relations/rel_associates_material.rs
@@ -70,7 +70,7 @@ impl Deref for RelAssociatesMaterial {
 impl IFCParse for RelAssociatesMaterial {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelAssociatesMaterial {
                 _: p_space_or_comment_surrounded("IFCRELASSOCIATESMATERIAL("),
 
                 rel_associates: RelAssociates::parse(),

--- a/ifc_rs/src/relations/rel_contained_in_spatial_structure.rs
+++ b/ifc_rs/src/relations/rel_contained_in_spatial_structure.rs
@@ -76,7 +76,7 @@ impl Deref for RelContainedInSpatialStructure {
 impl IFCParse for RelContainedInSpatialStructure {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelContainedInSpatialStructure {
                 _: p_space_or_comment_surrounded("IFCRELCONTAINEDINSPATIALSTRUCTURE("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/rel_declares.rs
+++ b/ifc_rs/src/relations/rel_declares.rs
@@ -71,7 +71,7 @@ impl Deref for RelDeclares {
 impl IFCParse for RelDeclares {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelDeclares {
                 _: p_space_or_comment_surrounded("IFCRELDECLARES("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/rel_defines_by_properties.rs
+++ b/ifc_rs/src/relations/rel_defines_by_properties.rs
@@ -73,7 +73,7 @@ impl Deref for RelDefinesByProperties {
 impl IFCParse for RelDefinesByProperties {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelDefinesByProperties {
                 _: p_space_or_comment_surrounded("IFCRELDEFINESBYPROPERTIES("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/rel_defines_by_type.rs
+++ b/ifc_rs/src/relations/rel_defines_by_type.rs
@@ -68,7 +68,7 @@ impl Deref for RelDefinesByType {
 impl IFCParse for RelDefinesByType {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelDefinesByType {
                 _: p_space_or_comment_surrounded("IFCRELDEFINESBYTYPE("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/rel_fills_element.rs
+++ b/ifc_rs/src/relations/rel_fills_element.rs
@@ -50,7 +50,7 @@ impl RootBuilder for RelFillsElement {
 impl IFCParse for RelFillsElement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelFillsElement {
                 _: p_space_or_comment_surrounded("IFCRELFILLSELEMENT("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/rel_voids_element.rs
+++ b/ifc_rs/src/relations/rel_voids_element.rs
@@ -54,7 +54,7 @@ impl RootBuilder for RelVoidsElement {
 impl IFCParse for RelVoidsElement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            RelVoidsElement {
                 _: p_space_or_comment_surrounded("IFCRELVOIDSELEMENT("),
 
                 root: Root::parse(),

--- a/ifc_rs/src/relations/representation_map.rs
+++ b/ifc_rs/src/relations/representation_map.rs
@@ -73,7 +73,7 @@ impl IFCParse for RepresentationMap {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            RepresentationMap {
                 _: p_space_or_comment_surrounded("IFCREPRESENTATIONMAP("),
                 origin: IdOr::parse(),
                 _: Comma::parse(),

--- a/ifc_rs/src/units/assignment.rs
+++ b/ifc_rs/src/units/assignment.rs
@@ -33,7 +33,7 @@ impl UnitAssigment {
 impl IFCParse for UnitAssigment {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            UnitAssigment {
                 _: p_space_or_comment_surrounded("IFCUNITASSIGNMENT("),
 
                 units: IfcList::parse(),

--- a/ifc_rs/src/units/conversion_based_unit.rs
+++ b/ifc_rs/src/units/conversion_based_unit.rs
@@ -43,7 +43,7 @@ impl Deref for ConversionBasedUnit {
 impl IFCParse for ConversionBasedUnit {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            ConversionBasedUnit {
                 _: p_space_or_comment_surrounded("IFCCONVERSIONBASEDUNIT("),
 
                 named_unit: NamedUnit::parse(),

--- a/ifc_rs/src/units/derived_unit.rs
+++ b/ifc_rs/src/units/derived_unit.rs
@@ -27,7 +27,7 @@ pub struct DerivedUnit {
 impl IFCParse for DerivedUnit {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            DerivedUnit {
                 _: p_space_or_comment_surrounded("IFCDERIVEDUNIT("),
 
                 elements: IfcList::parse(),

--- a/ifc_rs/src/units/derived_unit_element.rs
+++ b/ifc_rs/src/units/derived_unit_element.rs
@@ -22,7 +22,7 @@ pub struct DerivedUnitElement {
 impl IFCParse for DerivedUnitElement {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            DerivedUnitElement {
                 _: p_space_or_comment_surrounded("IFCDERIVEDUNITELEMENT("),
 
                 unit: Id::parse().map(TypedId::new),

--- a/ifc_rs/src/units/dimensional_exponents.rs
+++ b/ifc_rs/src/units/dimensional_exponents.rs
@@ -70,7 +70,7 @@ impl IFCParse for DimensionalExponents {
         Self: Sized,
     {
         winnow::seq! {
-            Self {
+            DimensionalExponents {
                 _: p_space_or_comment_surrounded("IFCDIMENSIONALEXPONENTS("),
                 length: dec_int,
                 _: Comma::parse(),

--- a/ifc_rs/src/units/measure/plane_angle.rs
+++ b/ifc_rs/src/units/measure/plane_angle.rs
@@ -18,7 +18,7 @@ pub struct PlaneAngleMeasure {
 impl IFCParse for PlaneAngleMeasure {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            PlaneAngleMeasure {
                 _: p_space_or_comment_surrounded("IFCPLANEANGLEMEASURE("),
 
                 value: RealPrimitive::parse(),

--- a/ifc_rs/src/units/measure_with_unit.rs
+++ b/ifc_rs/src/units/measure_with_unit.rs
@@ -27,7 +27,7 @@ pub struct MeasureWithUnit {
 impl IFCParse for MeasureWithUnit {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MeasureWithUnit {
                 _: p_space_or_comment_surrounded("IFCMEASUREWITHUNIT("),
 
                 value: IdOr::parse(),

--- a/ifc_rs/src/units/monetary_unit.rs
+++ b/ifc_rs/src/units/monetary_unit.rs
@@ -20,7 +20,7 @@ impl IfcType for MonetaryUnit {}
 impl IFCParse for MonetaryUnit {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            MonetaryUnit {
                 _: p_space_or_comment_surrounded("IFCMONETARYUNIT("),
 
                 currency: StringPrimitive::parse(),

--- a/ifc_rs/src/units/shared/named_unit.rs
+++ b/ifc_rs/src/units/shared/named_unit.rs
@@ -19,7 +19,7 @@ pub struct NamedUnit {
 impl IFCParse for NamedUnit {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            NamedUnit {
                 dimensions: OptionalParameter::parse(),
                 _: Comma::parse(),
                 unit_type: OptionalParameter::parse(),

--- a/ifc_rs/src/units/si_unit.rs
+++ b/ifc_rs/src/units/si_unit.rs
@@ -59,7 +59,7 @@ impl Deref for SiUnit {
 impl IFCParse for SiUnit {
     fn parse<'a>() -> impl IFCParser<'a, Self> {
         winnow::seq! {
-            Self {
+            SiUnit {
                 _: p_space_or_comment_surrounded("IFCSIUNIT("),
 
                 named_unit: NamedUnit::parse(),


### PR DESCRIPTION
Currently, when trying to debug past the `seq!` (via `--features winnow/debug`) the output is pretty bad/unusable:

![image](https://github.com/user-attachments/assets/f46e1e7c-2b44-4832-81c7-9e109c7c6c4e)

This PR makes this into the name of the struct which means that expansions look like this

![image](https://github.com/user-attachments/assets/1431b5d3-1a7c-46f2-98b7-6157523794d7)